### PR TITLE
Fix patch-package error during installation

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gnosis.pm/zodiac",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "description": "Zodiac is a composable design philosophy and collection of standards for building DAO ecosystem tooling.",
   "author": "Auryn Macmillan <auryn.macmillan@gnosis.io>",
   "license": "LGPL-3.0+",

--- a/package.json
+++ b/package.json
@@ -35,12 +35,11 @@
     "format": "yarn format:sol && yarn format:ts",
     "format:sol": "prettier --write --plugin=prettier-plugin-solidity ./contracts/**/*.sol",
     "format:ts": "prettier --write ./sdk/**/*.ts ./test/**/*.ts ./*.ts",
-    "generate:types": "rm -rf src/types && typechain --target ethers-v6 --out-dir sdk/types './sdk/abi/*.json'",
+    "generate:types": "patch-package && rm -rf src/types && typechain --target ethers-v6 --out-dir sdk/types './sdk/abi/*.json'",
     "prepare": "yarn generate:types && yarn build",
     "prerelease": "yarn clean && yarn build && yarn build:sdk",
     "release": "yarn publish --access public",
-    "verify": "yarn hardhat verify --network",
-    "postinstall": "patch-package"
+    "verify": "yarn hardhat verify --network"
   },
   "directories": {
     "test": "test"
@@ -77,7 +76,6 @@
     "hardhat-deploy": "^0.11.28",
     "hardhat-gas-reporter": "^1.0.9",
     "husky": "^8.0.1",
-    "patch-package": "^8.0.0",
     "prettier": "^3.0.3",
     "prettier-plugin-solidity": "^1.1.3",
     "rimraf": "^5.0.1",
@@ -87,7 +85,8 @@
     "ts-node": "^10.9.1",
     "typechain": "^8.3.2",
     "typescript": "^5.2.2",
-    "yargs": "^17.6.0"
+    "yargs": "^17.6.0",
+    "patch-package": "^8.0.0"
   },
   "dependencies": {
     "@gnosis.pm/mock-contract": "^4.0.0",


### PR DESCRIPTION


## Fix a bug

fixes #153 

### Bug Report

Installing 4.0.0 was failing due to patch-package being a dev dependencies and the patches folder missing in the final pkg.


### Implementation

I was thinking of adding a patch-package step to the actions workflow, but this would mean that people installing would need to extra run the step. So I decided to move patch-package to dependencies and include the patch in the dist. 

This would increatese file size, but I think it is the most developer friendly solution.


### Additional Context

*Add any other context about the implementation here.*


This PR:

- [ ] Adds details of the module to the [README](../../README.md) (items are sorted alphabetically)
- [ ] Adds addresses of the canonical deployments of the mastercopy for your module to [deployments.json](../../src/deployments.json), along with addresses and ABI details to [constants.ts](../../src/factory/constants.ts). Ideally these should be deterministic deployments that can be easily replicated on other supported networks.
- [ ] Includes an audit from a reputable auditor.