### PR TITLE
feat: core networks for osnap

### DIFF
--- a/sdk/contracts.ts
+++ b/sdk/contracts.ts
@@ -53,6 +53,7 @@ export enum SupportedNetworks {
   HardhatNetwork = 31337,
   LineaGoerli = 59140,
   Sepolia = 11155111,
+  CoreTestnet = 1115,
 }
 
 // const canonicalMasterCopyAddress = (contract: KnownContracts) => {
@@ -215,6 +216,12 @@ export const ContractVersions: Record<
   },
   [SupportedNetworks.LineaGoerli]: CanonicalAddresses,
   [SupportedNetworks.Sepolia]: CanonicalAddresses,
+  [SupportedNetworks.CoreTestnet]: {
+    ...CanonicalAddresses,
+    [KnownContracts.OPTIMISTIC_GOVERNOR]: {
+      "1.2.0": "0xD43463Fadd73373bE260b67F5825274F4403dAF0",
+    },
+  },
 };
 
 /** Addresses of the head versions of all contracts */

--- a/sdk/contracts.ts
+++ b/sdk/contracts.ts
@@ -54,6 +54,7 @@ export enum SupportedNetworks {
   LineaGoerli = 59140,
   Sepolia = 11155111,
   CoreTestnet = 1115,
+  Core = 1116,
 }
 
 // const canonicalMasterCopyAddress = (contract: KnownContracts) => {
@@ -220,6 +221,12 @@ export const ContractVersions: Record<
     ...CanonicalAddresses,
     [KnownContracts.OPTIMISTIC_GOVERNOR]: {
       "1.2.0": "0xD43463Fadd73373bE260b67F5825274F4403dAF0",
+    },
+  },
+  [SupportedNetworks.Core]: {
+    ...CanonicalAddresses,
+    [KnownContracts.OPTIMISTIC_GOVERNOR]: {
+      "1.2.0": "0x596Fd6A5A185c67aBD1c845b39f593fBA9C233aa",
     },
   },
 };

--- a/sdk/contracts.ts
+++ b/sdk/contracts.ts
@@ -53,8 +53,8 @@ export enum SupportedNetworks {
   HardhatNetwork = 31337,
   LineaGoerli = 59140,
   Sepolia = 11155111,
-  CoreTestnet = 1115,
-  Core = 1116,
+  CoreTestnet = 1115, // limited to UMA oSnap support (OPTIMISTIC_GOVERNOR)
+  Core = 1116, // // limited to UMA oSnap support (OPTIMISTIC_GOVERNOR)
 }
 
 // const canonicalMasterCopyAddress = (contract: KnownContracts) => {


### PR DESCRIPTION
## Add a feature

### Feature Request

Add support of UMA oSnap modules on Core networks (https://coredao.org/)

### Implementation

Add support by deploying module proxy factory and oSnap module mastercopy on Core mainnet/testnet

### Additional Context

- SingletonFactory deployed at `0xce0042B868300000d44A59004Da54A005ffdcf9f` for [mainnet](https://scan.coredao.org/address/0xce0042B868300000d44A59004Da54A005ffdcf9f)/[testnet](https://scan.test.btcs.network/address/0xce0042b868300000d44a59004da54a005ffdcf9f)
- ModuleProxyFactory deployed at `0x000000000000aDdB49795b0f9bA5BC298cDda236` for [mainnet](https://scan.coredao.org/address/0x000000000000aDdB49795b0f9bA5BC298cDda236)/[testnet](https://scan.test.btcs.network/address/0x000000000000aDdB49795b0f9bA5BC298cDda236)
- OptimisticGovernor mastercopy deployed at `0x596Fd6A5A185c67aBD1c845b39f593fBA9C233aa` for [mainnet](https://scan.coredao.org/address/0x596Fd6A5A185c67aBD1c845b39f593fBA9C233aa)
- OptimisticGovernor mastercopy deployed at `0xD43463Fadd73373bE260b67F5825274F4403dAF0` for [testnet](https://scan.test.btcs.network/address/0xD43463Fadd73373bE260b67F5825274F4403dAF0)