### PR TITLE
feat: add base support

### DIFF
--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -118,6 +118,10 @@ export default {
       ...sharedNetworkConfig,
       url: "https://rpc.test.btcs.network",
     },
+    base: {
+      ...sharedNetworkConfig,
+      url: "https://mainnet.base.org",
+    }
   },
   namedAccounts: {
     deployer: 0,
@@ -142,6 +146,14 @@ export default {
         urls: {
           apiURL: "https://openapi.coredao.org/api",
           browserURL: "https://scan.coredao.org/",
+        },
+      },
+      {
+        network: "base",
+        chainId: 8453,
+        urls: {
+          apiURL: "https://api.basescan.org/api",
+          browserURL: "https://basescan.org/",
         },
       },
     ],

--- a/sdk/contracts.ts
+++ b/sdk/contracts.ts
@@ -55,6 +55,7 @@ export enum SupportedNetworks {
   Sepolia = 11155111,
   CoreTestnet = 1115,
   Core = 1116,
+  Base = 8453
 }
 
 // const canonicalMasterCopyAddress = (contract: KnownContracts) => {
@@ -227,6 +228,12 @@ export const ContractVersions: Record<
     ...CanonicalAddresses,
     [KnownContracts.OPTIMISTIC_GOVERNOR]: {
       "1.2.0": "0x596Fd6A5A185c67aBD1c845b39f593fBA9C233aa",
+    },
+  },
+  [SupportedNetworks.Base]: {
+    ...CanonicalAddresses,
+    [KnownContracts.OPTIMISTIC_GOVERNOR]: {
+      "1.2.0": "0x80bCA2E1c272239AdFDCdc87779BC8Af6E12e633",
     },
   },
 };


### PR DESCRIPTION

## Add a feature

### Feature Request

Add support of UMA oSnap modules on Base network ([https://base.org/](https://base.org/))

### Implementation

Add support by deploying module proxy factory and oSnap module mastercopy on Base mainnet

### Additional Context

Also added hardhat config and ran  `deploy`  scripts:

```
base
    realityETH
  ✔ Mastercopy deployed to:        0x4e35DA39Fa5893a70A40Ce964F993d891E607cC0 🎉
    realityERC20
  ✔ Mastercopy deployed to:        0x7276813b21623d89BA8984B225d5792943DD7dbF 🎉
    bridge
  ✔ Mastercopy deployed to:        0x03B5eBD2CB2e3339E93774A1Eb7c8634B8C393A9 🎉
    delay
  ✔ Mastercopy deployed to:        0xd54895B1121A2eE3f37b502F507631FA1331BED6 🎉
    exit
  ✔ Mastercopy deployed to:        0x3ed380a282aDfA3460da28560ebEB2F6D967C9f5 🎉
    exitERC721
  ✔ Mastercopy deployed to:        0xE0eCE32Eb4BE4E9224dcec6a4FcB335c1fe05CDe 🎉
    circulatingSupplyERC20
  ✔ Mastercopy deployed to:        0x5Ed57C291a184cc244F5c9B5E9F11a8DD08BBd12 🎉
    circulatingSupplyERC721
  ✔ Mastercopy deployed to:        0xBD34D00dC0ae37C687F784A11FA6a0F2c5726Ba3 🎉
    scopeGuard
  ✔ Mastercopy deployed to:        0xeF27fcd3965a866b22Fb2d7C689De9AB7e611f1F 🎉
    factory
  ✔ Mastercopy already deployed to: 0x000000000000aDdB49795b0f9bA5BC298cDda236
    roles
  ✔ Mastercopy deployed to:        0xD8DfC1d938D7D163C5231688341e9635E9011889 🎉
    roles_v1
  ✔ Mastercopy already deployed to: 0xD8DfC1d938D7D163C5231688341e9635E9011889
    roles_v2
  ✔ Mastercopy deployed to:        0x9646fDAD06d3e24444381f44362a3B0eB343D337 🎉
    ozGovernor
  ✔ Mastercopy deployed to:        0xe28c39FAC73cce2B33C4C003049e2F3AE43f77d5 🎉
    erc20Votes
  ✔ Mastercopy deployed to:        0x752c61de75ADA0F8a33e048d2F773f51172f033e 🎉
    erc721Votes
  ✔ Mastercopy deployed to:        0xeFf38b2eBB95ACBA09761246045743f40e762568 🎉
    multisendEncoder
  ✔ Mastercopy deployed to:        0xb67EDe523171325345780fA3016b7F5221293df0 🎉
    permissions
  ✔ Mastercopy deployed to:        0x33D1C5A5B6a7f3885c7467e829aaa21698937597 🎉
    connext
  ✔ Mastercopy deployed to:        0x7dE07b9De0bf0FABf31A188DE1527034b2aF36dB 🎉
✨  Done in 117.92s.

```