### PR TITLE
Add Tellor Module Sepolia Address

### DIFF
--- a/sdk/contracts.ts
+++ b/sdk/contracts.ts
@@ -216,7 +216,12 @@ export const ContractVersions: Record<
     },
   },
   [SupportedNetworks.LineaGoerli]: CanonicalAddresses,
-  [SupportedNetworks.Sepolia]: CanonicalAddresses,
+  [SupportedNetworks.Sepolia]: {
+    ...CanonicalAddresses,
+    [KnownContracts.TELLOR]: {
+      "2.1.0": "0x5F05cd402BF4017970fe390D43B20C3dC3832CD9",
+    },
+  },
   [SupportedNetworks.CoreTestnet]: {
     ...CanonicalAddresses,
     [KnownContracts.OPTIMISTIC_GOVERNOR]: {


### PR DESCRIPTION
## Add a module to this repo

### Title

Tellor Zodiac Module - Add Sepolia Deployment

### Description

This PR simply adds the Sepolia deployment address for the Tellor Zodiac module.

### Checklist

*Prior to being merged, this PR must meet the following requirements.*

This PR:

- [X] Adds details of the module to the [README](../../README.md) (items are sorted alphabetically)
- [X] Adds addresses of the canonical deployments of the mastercopy for your module to [deployments.json](../../src/deployments.json), along with addresses and ABI details to [constants.ts](../../src/factory/constants.ts). Ideally these should be deterministic deployments that can be easily replicated on other supported networks.
- [X] Includes an audit from a reputable auditor.