### PR TITLE
Add support for Linea

### DIFF
--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -110,6 +110,11 @@ export default {
       ...sharedNetworkConfig,
       url: `https://linea-goerli.infura.io/v3/${INFURA_KEY}`,
     },
+    linea: {
+      ...sharedNetworkConfig,
+      // url: `https://linea.infura.io/v3/${INFURA_KEY}`,
+      url: "https://rpc.linea.build",
+    },
     core: {
       ...sharedNetworkConfig,
       url: "https://rpc.coredao.org",
@@ -121,7 +126,7 @@ export default {
     base: {
       ...sharedNetworkConfig,
       url: "https://mainnet.base.org",
-    }
+    },
   },
   namedAccounts: {
     deployer: 0,
@@ -154,6 +159,14 @@ export default {
         urls: {
           apiURL: "https://api.basescan.org/api",
           browserURL: "https://basescan.org/",
+        },
+      },
+      {
+        network: "linea",
+        chainId: 59144,
+        urls: {
+          apiURL: "https://api.lineascan.build/api",
+          browserURL: "https://lineascan.build/",
         },
       },
     ],

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -112,8 +112,7 @@ export default {
     },
     linea: {
       ...sharedNetworkConfig,
-      // url: `https://linea.infura.io/v3/${INFURA_KEY}`,
-      url: "https://rpc.linea.build",
+      url: `https://linea.infura.io/v3/${INFURA_KEY}`,
     },
     core: {
       ...sharedNetworkConfig,

--- a/sdk/contracts.ts
+++ b/sdk/contracts.ts
@@ -51,6 +51,7 @@ export enum SupportedNetworks {
   Avalanche = 43114,
   BinanceSmartChain = 56,
   HardhatNetwork = 31337,
+  Linea = 59144,
   LineaGoerli = 59140,
   Sepolia = 11155111,
   CoreTestnet = 1115,
@@ -216,6 +217,7 @@ export const ContractVersions: Record<
       "1.2.0": "0xEF8b46765ae805537053C59f826C3aD61924Db45",
     },
   },
+  [SupportedNetworks.Linea]: CanonicalAddresses,
   [SupportedNetworks.LineaGoerli]: CanonicalAddresses,
   [SupportedNetworks.Sepolia]: {
     ...CanonicalAddresses,


### PR DESCRIPTION
## Add a feature

### Feature Request

Adds support for Linea network

### Implementation

The contracts where already deployed at canonical addresses.

### Additional Context

```
➜  zodiac git:(master) ✗ yarn deploy linea
yarn run v1.22.22
$ hardhat deploy-replay --network linea

linea
    realityETH
  ✔ Mastercopy already deployed to: 0x4e35DA39Fa5893a70A40Ce964F993d891E607cC0
    realityERC20
  ✔ Mastercopy already deployed to: 0x7276813b21623d89BA8984B225d5792943DD7dbF
    bridge
  ✔ Mastercopy already deployed to: 0x03B5eBD2CB2e3339E93774A1Eb7c8634B8C393A9
    delay
  ✔ Mastercopy already deployed to: 0xd54895B1121A2eE3f37b502F507631FA1331BED6
    exit
  ✔ Mastercopy already deployed to: 0x3ed380a282aDfA3460da28560ebEB2F6D967C9f5
    exitERC721
  ✔ Mastercopy already deployed to: 0xE0eCE32Eb4BE4E9224dcec6a4FcB335c1fe05CDe
    circulatingSupplyERC20
  ✔ Mastercopy already deployed to: 0x5Ed57C291a184cc244F5c9B5E9F11a8DD08BBd12
    circulatingSupplyERC721
  ✔ Mastercopy already deployed to: 0xBD34D00dC0ae37C687F784A11FA6a0F2c5726Ba3
    scopeGuard
  ✔ Mastercopy already deployed to: 0xeF27fcd3965a866b22Fb2d7C689De9AB7e611f1F
    factory
  ✔ Mastercopy already deployed to: 0x000000000000aDdB49795b0f9bA5BC298cDda236
    roles
  ✔ Mastercopy already deployed to: 0xD8DfC1d938D7D163C5231688341e9635E9011889
    roles_v1
  ✔ Mastercopy already deployed to: 0xD8DfC1d938D7D163C5231688341e9635E9011889
    roles_v2
  ✔ Mastercopy already deployed to: 0x9646fDAD06d3e24444381f44362a3B0eB343D337
    ozGovernor
  ✔ Mastercopy already deployed to: 0xe28c39FAC73cce2B33C4C003049e2F3AE43f77d5
    erc20Votes
  ✔ Mastercopy already deployed to: 0x752c61de75ADA0F8a33e048d2F773f51172f033e
    erc721Votes
  ✔ Mastercopy already deployed to: 0xeFf38b2eBB95ACBA09761246045743f40e762568
    multisendEncoder
  ✔ Mastercopy already deployed to: 0xb67EDe523171325345780fA3016b7F5221293df0
    permissions
  ✔ Mastercopy already deployed to: 0x33D1C5A5B6a7f3885c7467e829aaa21698937597
    connext
  ✔ Mastercopy already deployed to: 0x7dE07b9De0bf0FABf31A188DE1527034b2aF36dB
✨  Done in 11.07s.
```
